### PR TITLE
remove framework bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
   "require": {
     "php": "^7.1",
     "contao/core-bundle": "^4.4",
-    "symfony/framework-bundle": "^3.4",
     "heimrichhannot/contao-utils-bundle": "^2.5"
   },
   "require-dev": {


### PR DESCRIPTION
Since this bundle does not actually use any component of the symfony/framework-bundle, it should be removed - otherwise it cannot be installed in every Contao installation.